### PR TITLE
Fixes #4: Support all default rulesets supported by phpcs

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -14,9 +14,23 @@ GITHUB_REPO_OWNER=${GITHUB_REPOSITORY%%/*}
 
 phpcs_standard=''
 
-if [[ -f "$RTBOT_WORKSPACE/phpcs.xml" ]]; then
-    phpcs_standard="--phpcs-standard=$RTBOT_WORKSPACE/phpcs.xml"
-else
+defaultFiles=(
+  '.phpcs.xml'
+  'phpcs.xml'
+  '.phpcs.xml.dist'
+  'phpcs.xml.dist'
+)
+
+phpcsfilefound=1
+
+for phpcsfile in "${defaultFiles[@]}"; do
+  if [[ -f "$RTBOT_WORKSPACE/$phpcsfile" ]]; then
+      phpcs_standard="--phpcs-standard=$RTBOT_WORKSPACE/$phpcsfile"
+      phpcsfilefound=0
+  fi
+done
+
+if [[ $phpcsfilefound -ne 0 ]]; then
     if [[ -n "$1" ]]; then
       phpcs_standard="--phpcs-standard=$1"
     else


### PR DESCRIPTION
Follow the same order as PHPCS

> for a file called either .phpcs.xml, phpcs.xml, .phpcs.xml.dist, or phpcs.xml.dist. If found, configuration information will be read from this file

https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>