### PR TITLE
Add feature to skip any dir/subdir from scanning

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -17,6 +17,17 @@ stars=$(printf "%-30s" "*")
 export RTBOT_WORKSPACE="/home/rtbot/github-workspace"
 hosts_file="$GITHUB_WORKSPACE/.github/hosts.yml"
 
+# Delete all the folders to be skipped to ignore them from being scanned.
+if [[ -n "$SKIP_FOLDERS" ]]; then
+
+  folders=(${SKIP_FOLDERS//,/ })
+
+  for folder in ${folders[@]}; do
+    path_of_folder="$GITHUB_WORKSPACE/$folder"
+    [[ -d "$path_of_folder" ]] && rm -rf $path_of_folder
+  done
+fi
+
 rsync -a "$GITHUB_WORKSPACE/" "$RTBOT_WORKSPACE"
 rsync -a /root/vip-go-ci-tools/ /home/rtbot/vip-go-ci-tools
 chown -R rtbot:rtbot /home/rtbot/


### PR DESCRIPTION
Previously only skipping of top level directories was possible. Now skipping of any subdir will also be possible.

Signed-off-by: Riddhesh Sanghvi <riddhesh237@gmail.com>