### PR TITLE
Add option to skip linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ jobs:
       env:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         SKIP_FOLDERS: "tests,.github"
-        SKIP_LINT: "no"
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"
 ```
@@ -67,7 +66,7 @@ Private   | Complete `repo` and `write:discussion` permissions  | [Screenshot Pr
 Variable       | Default | Possible  Values            | Purpose
 ---------------|---------|-----------------------------|----------------------------------------------------
 `SKIP_FOLDERS` | -       | `tests`,`tests,.github` (Any other comma seprated top level directories in the repo)     | If any specific folders should be ignored when scanning, then a comma seprated list of values should be added to this env variable.
-`SKIP_LINT`    | `no`    | `1`, `yes`, `true` or any other value to indicate *false*                                | If the automatic linting of all PHP files should be deactivated, then this env variable should be set to a truthy value (see *Possible Values*).
+`PHP_LINT`     | `true`  | `true` or `false`, *case insensitive* (Any unknown value is the same as passing `true`)  | If the default automatic linting of all PHP files should be deactivated, then this env variable should be set to `false`.
 
 ## PHPCS Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
       env:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         SKIP_FOLDERS: "tests,.github"
+        SKIP_LINT: "no"
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"
 ```
@@ -44,6 +45,8 @@ Now, next time you create a pull request or commit on an existing pull request, 
 By default, pull request will be reviwed using WordPress coding and documentation standards. You can change the default by passing different [PHPCS Coding Standard(s)](#phpcs-coding-standards) in line `args = ["WordPress-Core,WordPress-Docs"]`.
 
 4. In case you want to skip PHPCS scanning in any pull request, add `[do-not-scan]` in the PR description. You can add it anywhere in the description and it will skip the action run for that pull request.
+
+5. In case you want to skip linting all files on every pull request, set `SKIP_LINT` to `1`, `yes` or `true`.
 
 ## GitHub Token Creation
 
@@ -64,6 +67,7 @@ Private   | Complete `repo` and `write:discussion` permissions  | [Screenshot Pr
 Variable       | Default | Possible  Values            | Purpose
 ---------------|---------|-----------------------------|----------------------------------------------------
 `SKIP_FOLDERS` | -       | `tests`,`tests,.github` (Any other comma seprated top level directories in the repo)     | If any specific folders should be ignored when scanning, then a comma seprated list of values should be added to this env variable.
+`SKIP_LINT`    | `no`    | `1`, `yes`, `true` or any other value to indicate *false*                                | If the automatic linting of all PHP files should be deactivated, then this env variable should be set to a truthy value (see *Possible Values*).
 
 ## PHPCS Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ By default, pull request will be reviwed using WordPress coding and documentatio
 
 4. In case you want to skip PHPCS scanning in any pull request, add `[do-not-scan]` in the PR description. You can add it anywhere in the description and it will skip the action run for that pull request.
 
-5. In case you want to skip linting all files on every pull request, set `SKIP_LINT` to `1`, `yes` or `true`.
+5. In case you want to skip linting all files on every pull request, set `PHP_LINT` to `false`.
 
 ## GitHub Token Creation
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This will run phpcs on PRs'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://rtcamp/action-phpcs-code-review:v2.0.2'
+  image: 'docker://rtcamp/action-phpcs-code-review:v2.0.3'
 branding:
   icon: 'check-circle'
   color: 'green'

--- a/main.sh
+++ b/main.sh
@@ -69,9 +69,12 @@ fi
 
 /usr/games/cowsay "Running with the flag $phpcs_standard"
 
-[[ ":1:yes:true:" = *:$SKIP_LINT:* ]] && lint_option='--lint=false' || lint_option='--lint=true'
+php_lint_option='--lint=true'
+if [[ "$(echo "$PHP_LINT" | tr '[:upper:]' '[:lower:]')" = 'false' ]]; then
+  php_lint_option='--lint=false'
+fi
 
 echo "Running the following command"
-echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $lint_option"
+echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $php_lint_option"
 
-gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $lint_option"
+gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $php_lint_option"

--- a/main.sh
+++ b/main.sh
@@ -69,7 +69,9 @@ fi
 
 /usr/games/cowsay "Running with the flag $phpcs_standard"
 
-echo "Running the following command"
-echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option --lint=true"
+[[ ":1:yes:true:" = *:$SKIP_LINT:* ]] && lint_option='--lint=false' || lint_option='--lint=true'
 
-gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option --lint=true"
+echo "Running the following command"
+echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $lint_option"
+
+gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $lint_option"


### PR DESCRIPTION
Adds an environment variable `SKIP_LINT` to allow skipping the default linting of all PHP files (thus reducing the runtime significantly).