### PR TITLE
Trim whitespaces from GitHub token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This will run phpcs on PRs'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://rtcamp/action-phpcs-code-review:v2.0.3'
+  image: 'docker://rtcamp/action-phpcs-code-review:v2.0.4'
 branding:
   icon: 'check-circle'
   color: 'green'

--- a/main.sh
+++ b/main.sh
@@ -39,6 +39,9 @@ if [[ -n "$VAULT_GITHUB_TOKEN" ]] || [[ -n "$VAULT_TOKEN" ]]; then
   export GH_BOT_TOKEN=$(vault read -field=token secret/rtBot-token)
 fi
 
+# Remove spaces from GitHub token, at times copying token can give leading space.
+GH_BOT_TOKEN=${GH_BOT_TOKEN//[[:blank:]]/}
+
 phpcs_standard=''
 
 defaultFiles=(


### PR DESCRIPTION
Remove spaces from GitHub token if any, at times copying token from GitHub UI can give leading space.

Ref: #36 