### PR TITLE
Add option to exclude phpcs sniffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
       env:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         SKIP_FOLDERS: "tests,.github"
+        PHPCS_SNIFFS_EXCLUDE: "WordPress.Files.FileName"
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"
 ```
@@ -66,6 +67,7 @@ Private   | Complete `repo` and `write:discussion` permissions  | [Screenshot Pr
 Variable       | Default | Possible  Values            | Purpose
 ---------------|---------|-----------------------------|----------------------------------------------------
 `SKIP_FOLDERS` | -       | `tests`,`tests,.github` (Any other comma seprated top level directories in the repo)     | If any specific folders should be ignored when scanning, then a comma seprated list of values should be added to this env variable.
+`PHPCS_SNIFFS_EXCLUDE` | -       | `WordPress.Files.FileName`, `WordPress.Files.FileName,Generic.Arrays.DisallowShortArraySyntax` | Single sniff or comma seprated list of sniffs to be excluded from the phpcs scan.
 `PHP_LINT`     | `true`  | `true` or `false`, *case insensitive* (Any unknown value is the same as passing `true`)  | If the default automatic linting of all PHP files should be deactivated, then this env variable should be set to `false`.
 
 ## PHPCS Coding Standards

--- a/main.sh
+++ b/main.sh
@@ -68,6 +68,8 @@ if [[ $phpcsfilefound -ne 0 ]]; then
     fi
 fi
 
+[[ -z "$PHPCS_SNIFFS_EXCLUDE" ]] && phpcs_sniffs_exclude='' || phpcs_sniffs_exclude="--phpcs-sniffs-exclude='$PHPCS_SNIFFS_EXCLUDE'"
+
 [[ -z "$SKIP_FOLDERS" ]] && skip_folders_option='' || skip_folders_option="--skip-folders='$SKIP_FOLDERS'" 
 
 /usr/games/cowsay "Running with the flag $phpcs_standard"
@@ -80,4 +82,4 @@ fi
 echo "Running the following command"
 echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $php_lint_option"
 
-gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $php_lint_option"
+gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $phpcs_sniffs_exclude $skip_folders_option $php_lint_option"

--- a/main.sh
+++ b/main.sh
@@ -80,6 +80,6 @@ if [[ "$(echo "$PHP_LINT" | tr '[:upper:]' '[:lower:]')" = 'false' ]]; then
 fi
 
 echo "Running the following command"
-echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $skip_folders_option $php_lint_option"
+echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $phpcs_sniffs_exclude $skip_folders_option $php_lint_option"
 
 gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $phpcs_sniffs_exclude $skip_folders_option $php_lint_option"


### PR DESCRIPTION
Ref: #35 

Adding env var: `PHPCS_SNIFFS_EXCLUDE` which can be configured with comma-separated values of sniffs to be excluded while running this action.