### PR TITLE
Updates for allowing options from vip-go-ci.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ jobs:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         SKIP_FOLDERS: "tests,.github"
         PHPCS_SNIFFS_EXCLUDE: "WordPress.Files.FileName"
+        PHPCS_STANDARD_FILE_NAME: 'phpcs.ruleset.xml'
+        PHPCS_FILE_PATH: 'vendor/bin/phpcs'
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"
 ```
@@ -69,6 +71,44 @@ Variable       | Default | Possible  Values            | Purpose
 `SKIP_FOLDERS` | -       | `tests`,`tests,.github` (Any other comma seprated top level directories in the repo)     | If any specific folders should be ignored when scanning, then a comma seprated list of values should be added to this env variable.
 `PHPCS_SNIFFS_EXCLUDE` | -       | `WordPress.Files.FileName` (Any other comma seprated list of valid sniffs) | Single sniff or comma seprated list of sniffs to be excluded from the phpcs scan.
 `PHP_LINT`     | `true`  | `true` or `false`, *case insensitive* (Any unknown value is the same as passing `true`)  | If the default automatic linting of all PHP files should be deactivated, then this env variable should be set to `false`.
+`PHPCS_STANDARD_FILE_NAME`     |  -  | phpcs ruleset file from project root dir. i.e phpcs.ruleset.xml | PHP_CodeSniffer ruleset filename. Default filename available: '.phpcs.xml', 'phpcs.xml', '.phpcs.xml.dist', 'phpcs.xml.dist'
+`PHPCS_FILE_PATH`     |  -  | Custom phpcs execution file path from project. i.e Composer phpcs path. 'vendor/bin/phpcs' | This is useful in case of needed to use any custom coding standards apart from pre-defined in VIP/WP Coding Standards. 
+
+## Modifying the bot’s behavior
+You can change the bot’s behavior by placing a configuration file named `.vipgoci_options` at the root of the relevant repository. This file must contain a valid JSON string for this to work; if the file is not parsable, it will be ignored. This file is where you can add code to turn off support messages as well as adjust PHPCS severity levels.
+
+i.e: You can update phpcs severity:
+```json
+{
+  "phpcs-severity": 5
+}
+```
+
+Allowed options:
+- `"skip-execution"`
+- `"skip-draft-prs"`
+- `"results-comments-sort"`
+- `"review-comments-include-severity"`
+- `"phpcs"`
+- `"phpcs-severity"`
+- `"post-generic-pr-support-comments"`
+- `"phpcs-sniffs-include"`
+- `"phpcs-sniffs-exclude"`
+- `"hashes-api"`
+- `"svg-checks"`
+- `"autoapprove"`
+- `"autoapprove-php-nonfunctional-changes`
+
+## Skipping PHPCS scanning for specific folders
+You can add files to the root of the repository indicating folders that should not be scanned. For PHPCS, the file should be named `.vipgoci_phpcs_skip_folders`. For PHP Linting the file should be named `.vipgoci_lint_skip_folders`. Please ensure both files are located in the root of the repository. 
+
+List each folder to be skipped on individual lines within those files.
+i.e: 
+```
+tests
+vendor
+node_modules
+``` 
 
 ## PHPCS Coding Standards
 
@@ -97,11 +137,23 @@ By default, `WordPress-Core,WordPress-Docs` value is passed.
 
 ### Custom Sniffs
 
+Default filename supported:
+- `.phpcs.xml`
+- `phpcs.xml`
+- `.phpcs.xml.dist`
+- `phpcs.xml.dist`
+
 If your git repo have a file named `phpcs.xml` in the root of the repository, then that will take precedence. In that case, value passed to args such as `args = ["WordPress,WordPress-Core,WordPress-Docs"]` will be ignored.
 
 If your git repo doesn't have `phpcs.xml` and you do not specify `args` in `main.workflow` PHPCS action, then this actions will fallback to default.
 
+If your git repo have phpcs ruleset file other than default filename list, use `PHPCS_STANDARD_FILE_NAME` environment var to provide filename.
+
 Here is a sample [phpcs.xml](https://github.com/rtCamp/github-actions-wordpress-skeleton/blob/master/phpcs.xml) you can use in case you want to use custom sniffs.
+
+### Custom Coding Standards
+
+If you have custom coding standards from your git repository, you can use composer and use `phpcs` from execution from your repository phpcs file with the help of `PHPCS_FILE_PATH` environment variable.
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,13 @@ List each folder to be skipped on individual lines within those files.
 
 i.e:
 ```
-tests
+foo
+tests/bar
 vendor
 node_modules
 ```
+
+For more details, please check the documentation [here](https://github.com/automattic/vip-go-ci#skipping-certain-folders).
 
 ## PHPCS Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ jobs:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         SKIP_FOLDERS: "tests,.github"
         PHPCS_SNIFFS_EXCLUDE: "WordPress.Files.FileName"
-        PHPCS_STANDARD_FILE_NAME: 'phpcs.ruleset.xml'
-        PHPCS_FILE_PATH: 'vendor/bin/phpcs'
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"
 ```

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Variable       | Default | Possible  Values            | Purpose
 `PHPCS_SNIFFS_EXCLUDE` | -       | `WordPress.Files.FileName` (Any other comma seprated list of valid sniffs) | Single sniff or comma seprated list of sniffs to be excluded from the phpcs scan.
 `PHP_LINT`     | `true`  | `true` or `false`, *case insensitive* (Any unknown value is the same as passing `true`)  | If the default automatic linting of all PHP files should be deactivated, then this env variable should be set to `false`.
 `PHPCS_STANDARD_FILE_NAME`     |  -  | phpcs ruleset file from project root dir. i.e phpcs.ruleset.xml | PHP_CodeSniffer ruleset filename. Default filename available: '.phpcs.xml', 'phpcs.xml', '.phpcs.xml.dist', 'phpcs.xml.dist'
-`PHPCS_FILE_PATH`     |  -  | Custom phpcs execution file path from project. i.e Composer phpcs path. 'vendor/bin/phpcs' | This is useful in case of needed to use any custom coding standards apart from pre-defined in VIP/WP Coding Standards. 
+`PHPCS_FILE_PATH`     |  -  | Custom phpcs execution file path from project. i.e Composer phpcs path. 'vendor/bin/phpcs' | This is useful in case of needed to use any custom coding standards apart from pre-defined in VIP/WP Coding Standards.
 
 ## Modifying the bot’s behavior
+
 You can change the bot’s behavior by placing a configuration file named `.vipgoci_options` at the root of the relevant repository. This file must contain a valid JSON string for this to work; if the file is not parsable, it will be ignored. This file is where you can add code to turn off support messages as well as adjust PHPCS severity levels.
 
 i.e: You can update phpcs severity:
@@ -99,16 +100,19 @@ Allowed options:
 - `"autoapprove"`
 - `"autoapprove-php-nonfunctional-changes`
 
+For more details please check the documentation for [all options here](https://github.com/automattic/vip-go-ci#configuration-via-repository-config-file).
 ## Skipping PHPCS scanning for specific folders
-You can add files to the root of the repository indicating folders that should not be scanned. For PHPCS, the file should be named `.vipgoci_phpcs_skip_folders`. For PHP Linting the file should be named `.vipgoci_lint_skip_folders`. Please ensure both files are located in the root of the repository. 
+
+You can add files to the root of the repository indicating folders that should not be scanned. For PHPCS, the file should be named `.vipgoci_phpcs_skip_folders`. For PHP Linting the file should be named `.vipgoci_lint_skip_folders`. Please ensure both files are located in the root of the repository.
 
 List each folder to be skipped on individual lines within those files.
-i.e: 
+
+i.e:
 ```
 tests
 vendor
 node_modules
-``` 
+```
 
 ## PHPCS Coding Standards
 
@@ -143,11 +147,11 @@ Default filename supported:
 - `.phpcs.xml.dist`
 - `phpcs.xml.dist`
 
-If your git repo have a file named `phpcs.xml` in the root of the repository, then that will take precedence. In that case, value passed to args such as `args = ["WordPress,WordPress-Core,WordPress-Docs"]` will be ignored.
+If your git repo has a file named `phpcs.xml` in the root of the repository, then that will take precedence. In that case, value passed to args such as `args = ["WordPress,WordPress-Core,WordPress-Docs"]` will be ignored.
 
 If your git repo doesn't have `phpcs.xml` and you do not specify `args` in `main.workflow` PHPCS action, then this actions will fallback to default.
 
-If your git repo have phpcs ruleset file other than default filename list, use `PHPCS_STANDARD_FILE_NAME` environment var to provide filename.
+If your git repo has phpcs ruleset file other than default filename list, use `PHPCS_STANDARD_FILE_NAME` environment var to provide filename.
 
 Here is a sample [phpcs.xml](https://github.com/rtCamp/github-actions-wordpress-skeleton/blob/master/phpcs.xml) you can use in case you want to use custom sniffs.
 

--- a/main.sh
+++ b/main.sh
@@ -68,9 +68,19 @@ if [[ $phpcsfilefound -ne 0 ]]; then
     fi
 fi
 
+if [[ -n "$PHPCS_STANDARD_FILE_NAME" ]] && [[ -f "$RTBOT_WORKSPACE/$PHPCS_STANDARD_FILE_NAME" ]]; then
+  phpcs_standard="--phpcs-standard=$RTBOT_WORKSPACE/$PHPCS_STANDARD_FILE_NAME"
+fi;
+
+if [[ -n "$PHPCS_FILE_PATH" ]] && [[ -f "$RTBOT_WORKSPACE/$PHPCS_FILE_PATH" ]]; then
+  phpcs_file_path="--phpcs-path='$RTBOT_WORKSPACE/$PHPCS_FILE_PATH'"
+else
+  phpcs_file_path="--phpcs-path='/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs'"
+fi
+
 [[ -z "$PHPCS_SNIFFS_EXCLUDE" ]] && phpcs_sniffs_exclude='' || phpcs_sniffs_exclude="--phpcs-sniffs-exclude='$PHPCS_SNIFFS_EXCLUDE'"
 
-[[ -z "$SKIP_FOLDERS" ]] && skip_folders_option='' || skip_folders_option="--skip-folders='$SKIP_FOLDERS'" 
+[[ -z "$SKIP_FOLDERS" ]] && skip_folders_option='' || skip_folders_option="--skip-folders='$SKIP_FOLDERS'"
 
 /usr/games/cowsay "Running with the flag $phpcs_standard"
 
@@ -80,6 +90,37 @@ if [[ "$(echo "$PHP_LINT" | tr '[:upper:]' '[:lower:]')" = 'false' ]]; then
 fi
 
 echo "Running the following command"
-echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=\$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $phpcs_sniffs_exclude $skip_folders_option $php_lint_option --informational-url='https://github.com/rtCamp/action-phpcs-code-review/'"
+echo "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php \
+  --phpcs-skip-folders-in-repo-options-file=true \
+  --lint-skip-folders-in-repo-options-file=true \
+  --repo-options=true \
+  --phpcs=true \
+  --repo-owner=$GITHUB_REPO_OWNER \
+  --repo-name=$GITHUB_REPO_NAME \
+  --commit=$COMMIT_ID \
+  --token=\$GH_BOT_TOKEN \
+  --local-git-repo=$RTBOT_WORKSPACE \
+  $phpcs_file_path \
+  $phpcs_standard \
+  $phpcs_sniffs_exclude \
+  $skip_folders_option \
+  $php_lint_option \
+  --informational-url='https://github.com/rtCamp/action-phpcs-code-review/'"
 
-gosu rtbot bash -c "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php --repo-owner=$GITHUB_REPO_OWNER --repo-name=$GITHUB_REPO_NAME --commit=$COMMIT_ID --token=$GH_BOT_TOKEN --phpcs-path=/home/rtbot/vip-go-ci-tools/phpcs/bin/phpcs --local-git-repo=/home/rtbot/github-workspace --phpcs=true $phpcs_standard $phpcs_sniffs_exclude $skip_folders_option $php_lint_option --informational-url='https://github.com/rtCamp/action-phpcs-code-review/'"
+gosu rtbot bash -c \
+  "/home/rtbot/vip-go-ci-tools/vip-go-ci/vip-go-ci.php \
+  --phpcs-skip-folders-in-repo-options-file=true \
+  --lint-skip-folders-in-repo-options-file=true \
+  --repo-options=true \
+  --phpcs=true \
+  --repo-owner=$GITHUB_REPO_OWNER \
+  --repo-name=$GITHUB_REPO_NAME \
+  --commit=$COMMIT_ID \
+  --token=$GH_BOT_TOKEN \
+  --local-git-repo=$RTBOT_WORKSPACE \
+  $phpcs_file_path \
+  $phpcs_standard \
+  $phpcs_sniffs_exclude \
+  $skip_folders_option \
+  $php_lint_option \
+  --informational-url='https://github.com/rtCamp/action-phpcs-code-review/'"


### PR DESCRIPTION
Changes: 
- Add environment variables:
  - `PHPCS_STANDARD_FILE_NAME`: Allow custom ruleset filename.
  - `PHPCS_FILE_PATH`: Allow custom coding standard phpcs file path from repository.
- Modifying the bot’s behavior using `.vipgoci_options` file at the root of the relevant repository
- Skipping PHPCS scanning for specific folders options. Allow files: `.vipgoci_lint_skip_folders` and `vipgoci_phpcs_skip_folders`