### PR TITLE
Update image and vip-go-ci to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ubuntu:latest as of 2023-02-27
-FROM ubuntu@sha256:9a0bdde4188b896a372804be2384015e90e3f84906b750c1a53539b585fbbe7f
+FROM ubuntu@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
 
 LABEL "com.github.actions.icon"="check-circle"
 LABEL "com.github.actions.color"="green"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# ubuntu:latest as of 2023-02-27
+# ubuntu:latest as of 2023-11-15T09:52:14.989810029UTC
 FROM ubuntu@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
 
 LABEL "com.github.actions.icon"="check-circle"


### PR DESCRIPTION
Updating and building image will update vip-go-ci to latest via https://github.com/rtCamp/action-phpcs-code-review/blob/12b2bf4996526ce84c48ced863fe1579f1dd73ee/Dockerfile#L68-L70