### PR TITLE
Update image and add workflow for release and build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - mrrobot47
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: install docker emulation
+          run: docker run --rm --privileged tonistiigi/binfmt:latest --install amd64,arm64
+        - name: Set up buildx
+          uses: docker/setup-buildx-action@v3
+        - name: Login to ghcr.io
+          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        - name: Build and push
+          run: |
+            docker buildx build --platform linux/amd64,linux/arm64 -t $(echo 'ghcr.io/${{ github.repository }}:${{ github.ref_name }}' | tr '[:upper:]' '[:lower:]') --push .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - "v*"
+name: Release Creation
+jobs:
+  release:
+    name: Create a Draft Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Release Name
+      id: get_release_name
+      run: |
+        echo "release_name=${GITHUB_REF_NAME/v/Version }" >> $GITHUB_ENV
+    - name: Publish a Draft Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body: |
+          ## What's Changed
+
+          **Changelog:**
+        draft: true  # Creates a Draft Release
+        name: ${{ steps.get_release_name.outputs.release_name }}
+        generate_release_notes: true
+        append_body: true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ LABEL "com.github.actions.name"="PHPCS Code Review"
 LABEL "com.github.actions.description"="Run automated code review using PHPCS on your pull requests."
 LABEL "org.opencontainers.image.source"="https://github.com/rtCamp/action-phpcs-code-review"
 
-ARG VAULT_VERSION=1.12.3
 ARG DEFAULT_PHP_VERSION=8.3
 ARG PHP_BINARIES_TO_PREINSTALL='7.4 8.0 8.1 8.2 8.3'
 
@@ -32,9 +31,6 @@ RUN set -ex \
       php"$v"-xmlwriter; \
     done \
   && update-alternatives --set php /usr/bin/php${DEFAULT_PHP_VERSION} \
-  && wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
-  && unzip vault_${VAULT_VERSION}_linux_amd64.zip \
-  && mv vault /usr/local/bin/vault \
   # cleanup
   && rm -f vault_${VAULT_VERSION}_linux_amd64.zip \
   && apt-get remove software-properties-common unzip -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "com.github.actions.description"="Run automated code review using PHPCS on
 LABEL "org.opencontainers.image.source"="https://github.com/rtCamp/action-phpcs-code-review"
 
 ARG DEFAULT_PHP_VERSION=8.3
-ARG PHP_BINARIES_TO_PREINSTALL='7.4 8.0 8.1 8.2 8.3'
+ARG PHP_BINARIES_TO_PREINSTALL='7.4 8.0 8.1 8.2 8.3 8.4'
 
 ENV DOCKER_USER=rtbot
 ENV ACTION_WORKDIR=/home/$DOCKER_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN set -ex \
     done \
   && update-alternatives --set php /usr/bin/php${DEFAULT_PHP_VERSION} \
   # cleanup
-  && rm -f vault_${VAULT_VERSION}_linux_amd64.zip \
   && apt-get remove software-properties-common unzip -y \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \
@@ -48,8 +47,7 @@ RUN set -ex \
   && for v in $PHP_BINARIES_TO_PREINSTALL; do \
       php"$v" -v; \
     done \
-  && php -v \
-  && vault -v;
+  && php -v;
 
 COPY entrypoint.sh main.sh /usr/local/bin/
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This will run phpcs on PRs'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/rtcamp/action-phpcs-code-review:v3.0.2'
+  image: 'docker://ghcr.io/rtcamp/action-phpcs-code-review:v3.1.0'
 branding:
   icon: 'check-circle'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This will run phpcs on PRs'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/rtcamp/action-phpcs-code-review:v3.0.1'
+  image: 'docker://ghcr.io/rtcamp/action-phpcs-code-review:v3.0.2'
 branding:
   icon: 'check-circle'
   color: 'green'


### PR DESCRIPTION
This pull request introduces several updates to improve CI/CD workflows, enhance Docker configurations, and update dependencies. Key changes include adding Dependabot support for GitHub Actions, introducing new GitHub Actions workflows for building and releasing, and updating the Dockerfile to support PHP 8.4 while removing unused dependencies.

### CI/CD Workflow Enhancements:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R3-R8): Added Dependabot configuration to manage GitHub Actions dependencies with weekly updates and assigned `mrrobot47` as a reviewer.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R25): Introduced a new build workflow triggered by tag pushes or manual dispatch. It includes steps for Docker emulation, buildx setup, and multi-platform Docker image builds and pushes to GitHub Container Registry.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R26): Added a release workflow triggered by tags starting with `v*`. This workflow creates a draft release on GitHub with autogenerated release notes.

### Dockerfile Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L8-R9): Added support for PHP 8.4 in the `PHP_BINARIES_TO_PREINSTALL` argument. Removed the installation of HashiCorp Vault as it is no longer required. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L8-R9) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L35-L37)

### Dependency Updates:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L6-R6): Updated the Docker image version for the GitHub Action from `v3.0.1` to `v3.1.0`.